### PR TITLE
LIT-2791 - Modify auto-top-up service to limit number of un-expired NFTs per recipient

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ MONGO_DB_NAME=dev_task_db
 NFT_MINTER_KEY=1234567890123456789012345678901234
 NFT_MINTER_ADDRESS=0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
 RECIPIENT_LIST_URL=https://example.com/location/of/json_file.json
+LIT_NETWORK=cayenne

--- a/packages/lit-task-auto-top-up/.env.example
+++ b/packages/lit-task-auto-top-up/.env.example
@@ -1,3 +1,4 @@
 NFT_MINTER_KEY=1234567890123456789012345678901234
 NFT_MINTER_ADDRESS=0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
 RECIPIENT_LIST_URL=https://example.com/location/of/json_file.json
+LIT_NETWORK=cayenne

--- a/packages/lit-task-auto-top-up/package.json
+++ b/packages/lit-task-auto-top-up/package.json
@@ -35,13 +35,17 @@
     "@hokify/agenda": "^6.3.0",
     "@lit-protocol/contracts-sdk": "^4.1.1",
     "awaity": "^1.0.0",
+    "bs58": "^5.0.0",
     "consola": "^3.2.3",
+    "date-and-time": "2.4.1",
     "lodash": "^4.17.21",
+    "multiformats": "9.7.1",
     "verror": "^1.10.1",
     "viem": "^2.9.5",
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@types/date-and-time": "0.13.0",
     "chai": "^5.1.0"
   }
 }

--- a/packages/lit-task-auto-top-up/src/Classes/TaskHandler.ts
+++ b/packages/lit-task-auto-top-up/src/Classes/TaskHandler.ts
@@ -1,13 +1,16 @@
 import { Job } from '@hokify/agenda';
 import awaity from 'awaity'; // Awaity is a cjs package, breaks `import` with named imports in ESM
 import { ConsolaInstance } from 'consola';
+import date from 'date-and-time';
 import VError from 'verror';
 
 import { mintCapacityCreditNFT } from '../actions/mintCapacityCreditNFT';
 import { transferCapacityTokenNFT } from '../actions/transferCapacityTokenNFT';
 import { toErrorWithMessage } from '../errors';
+import { getLitContractsInstance } from '../singletons/getLitContracts';
 import { getRecipientList } from '../singletons/getRecipientList';
 import { tryTouchTask, printTaskResultsAndFailures } from '../taskHelpers';
+import { TaskResultEnum } from '../types/enums';
 import { Config, EnvConfig, RecipientDetail, TaskResult } from '../types/types';
 
 const { mapSeries } = awaity;
@@ -29,11 +32,74 @@ export class TaskHandler {
     recipientDetail: RecipientDetail;
   }): Promise<TaskResult> {
     const { recipientAddress } = recipientDetail;
+    const { noUnexpiredTokensTomorrow, unexpiredTokens } = await this.getExistingTokenDetails({
+      recipientAddress,
+    });
 
-    const capacityTokenIdStr = await mintCapacityCreditNFT({ recipientDetail });
-    await transferCapacityTokenNFT({ capacityTokenIdStr, recipientAddress });
+    if (noUnexpiredTokensTomorrow) {
+      const capacityTokenIdStr = await mintCapacityCreditNFT({ recipientDetail });
+      await transferCapacityTokenNFT({ capacityTokenIdStr, recipientAddress });
 
-    return { capacityTokenIdStr, ...recipientDetail };
+      return { capacityTokenIdStr, result: TaskResultEnum.minted, ...recipientDetail };
+    }
+
+    // If we got here, there should be some `unexpiredTokens` to log for clarity later.
+    return {
+      ...recipientDetail,
+      unexpiredTokens,
+      result: TaskResultEnum.skipped,
+    };
+  }
+
+  private async getExistingTokenDetails({ recipientAddress }: { recipientAddress: string }) {
+    const tomorrow = date.addDays(new Date(), 1);
+    const litContracts = await getLitContractsInstance();
+
+    // :sad_panda:, `getTokensByOwnerAddress()` returns <any> :(
+    const existingTokens: {
+      URI: { description: string; image_data: string; name: string };
+      capacity: {
+        expiresAt: { formatted: string; timestamp: number };
+        requestsPerMillisecond: number;
+      };
+      isExpired: boolean;
+      tokenId: number;
+    }[] =
+      await litContracts.rateLimitNftContractUtils.read.getTokensByOwnerAddress(recipientAddress);
+
+    // Only mint a new token if the recipient...
+    // 1. Has no NFTs at all
+    // 2. All unexpired NFTs they have will expire tomorrow
+    // 3. All of their NFTs are already expired
+    const noUnexpiredTokensTomorrow = existingTokens.every((token) => {
+      // NOTE: `every()` on an empty array === true :)
+      const {
+        capacity: {
+          expiresAt: { timestamp },
+        },
+        isExpired,
+      } = token;
+      if (isExpired) {
+        return true;
+      }
+      return date.isSameDay(new Date(timestamp), tomorrow);
+    });
+    return {
+      noUnexpiredTokensTomorrow,
+      unexpiredTokens: existingTokens
+        .filter(({ isExpired }) => !isExpired)
+        .map(
+          ({
+            capacity: {
+              expiresAt: { formatted },
+            },
+            tokenId,
+          }) => ({
+            tokenId,
+            expiresAt: formatted,
+          })
+        ),
+    };
   }
 
   async handleTask(task: Job) {
@@ -50,7 +116,7 @@ export class TaskHandler {
             this.handleRecipient({ recipientDetail }),
           ]);
 
-          this.logger.log(`Finished top-up for ${recipientDetail.recipientAddress}`);
+          this.logger.log(`Finished processing ${recipientDetail.recipientAddress}`);
           tryTouchTask(task).then(() => true); // Fire-and-forget; touching job is not critical
 
           return settledResult;
@@ -60,7 +126,7 @@ export class TaskHandler {
       printTaskResultsAndFailures({ results, logger: this.logger });
     } catch (e) {
       const err = toErrorWithMessage(e);
-      this.logger.error('CRITICAL ERROR', JSON.stringify(VError.info(err), null, 2));
+      this.logger.error('CRITICAL ERROR', e, JSON.stringify(VError.info(err), null, 2));
 
       // Re-throw so the job is retried by the task worker
       throw err;

--- a/packages/lit-task-auto-top-up/src/Classes/TaskHandler.ts
+++ b/packages/lit-task-auto-top-up/src/Classes/TaskHandler.ts
@@ -67,7 +67,7 @@ export class TaskHandler {
 
     // Only mint a new token if the recipient...
     // 1. Has no NFTs at all
-    // 2. All unexpired NFTs they have will expire tomorrow
+    // 2. All unexpired NFTs they have will expire later today or tomorrow
     // 3. All of their NFTs are already expired
     const noUsableTokensTomorrow = tokens.every((token) => {
       // NOTE: `every()` on an empty array === true :)

--- a/packages/lit-task-auto-top-up/src/types/enums.ts
+++ b/packages/lit-task-auto-top-up/src/types/enums.ts
@@ -1,0 +1,4 @@
+export enum TaskResultEnum {
+  minted = 'minted',
+  skipped = 'skipped',
+}

--- a/packages/lit-task-auto-top-up/src/types/types.ts
+++ b/packages/lit-task-auto-top-up/src/types/types.ts
@@ -22,3 +22,13 @@ export interface TaskResultSkipped extends RecipientDetail {
     tokenId: number;
   }[];
 }
+
+export type CapacityToken = {
+  URI: { description: string; image_data: string; name: string };
+  capacity: {
+    expiresAt: { formatted: string; timestamp: number };
+    requestsPerMillisecond: number;
+  };
+  isExpired: boolean;
+  tokenId: number;
+};

--- a/packages/lit-task-auto-top-up/src/types/types.ts
+++ b/packages/lit-task-auto-top-up/src/types/types.ts
@@ -1,6 +1,7 @@
 import { ConsolaInstance } from 'consola';
 import { z } from 'zod';
 
+import { TaskResultEnum } from './enums';
 import { recipientDetailSchema, envConfigSchema } from './schemas';
 
 export type EnvConfig = z.infer<typeof envConfigSchema>;
@@ -8,6 +9,16 @@ export type Config = { envConfig: EnvConfig; logger: ConsolaInstance };
 
 export type RecipientDetail = z.infer<typeof recipientDetailSchema>;
 
-export interface TaskResult extends RecipientDetail {
+export type TaskResult = TaskResultMinted | TaskResultSkipped;
+export interface TaskResultMinted extends RecipientDetail {
   capacityTokenIdStr: string;
+  result: TaskResultEnum.minted;
+}
+
+export interface TaskResultSkipped extends RecipientDetail {
+  result: TaskResultEnum.skipped;
+  unexpiredTokens: {
+    expiresAt: string;
+    tokenId: number;
+  }[];
 }

--- a/packages/lit-task-auto-top-up/tests/config.ts
+++ b/packages/lit-task-auto-top-up/tests/config.ts
@@ -10,7 +10,7 @@ const NFT_MINTER_KEY = '123456789012345678901234567890123';
 const LIT_NETWORK = 'manzano';
 const RECIPIENT_LIST_URL = 'https://example.com/json/file.json';
 
-const COMPLETE_CONFIG: EnvConfig = {
+export const COMPLETE_CONFIG: EnvConfig = {
   LIT_NETWORK,
   NFT_MINTER_ADDRESS,
   NFT_MINTER_KEY,

--- a/packages/lit-task-auto-top-up/tests/expiredTokens/expiredTokens.ts
+++ b/packages/lit-task-auto-top-up/tests/expiredTokens/expiredTokens.ts
@@ -1,0 +1,191 @@
+import { expect } from 'chai';
+import { createConsola } from 'consola';
+
+import { tokenFixtures, NOW, Expired, UnexpiredButInvalid, Unexpired } from './tokenFixtures';
+import { TaskHandler } from '../../src/index';
+import { CapacityToken } from '../../src/types/types';
+import { COMPLETE_CONFIG } from '../config';
+
+function getHandlerInstance() {
+  return new TaskHandler({
+    config: { envConfig: COMPLETE_CONFIG, logger: createConsola() },
+  });
+}
+
+function testAndAssert({
+  expired = [],
+  unexpired = [],
+  unexpiredButInvalid = [],
+}: {
+  expired?: CapacityToken[];
+  unexpired?: CapacityToken[];
+  unexpiredButInvalid?: CapacityToken[];
+}) {
+  const handlerInstance = getHandlerInstance();
+  const { noUsableTokensTomorrow, unexpiredTokens } = handlerInstance.getExistingTokenDetails({
+    today: NOW,
+    tokens: [...expired, ...unexpired, ...unexpiredButInvalid],
+  });
+
+  // Always verify we return the correct expired tokens for logging
+  const allUnexpired = [...unexpired, ...unexpiredButInvalid];
+
+  expect(unexpiredTokens).length(allUnexpired.length);
+  expect(unexpiredTokens)
+    .length(allUnexpired.length)
+    .deep.equals(allUnexpired.map(handlerInstance.mapUnexpiredToken));
+
+  if (unexpired.length > 0) {
+    expect(noUsableTokensTomorrow).false;
+    return false;
+  }
+
+  expect(noUsableTokensTomorrow).true;
+  return true;
+}
+describe('Expired Tokens', () => {
+  describe('noUnexpiredTokensTomorrow', () => {
+    it('should be `true` when there are no tokens at all', () => {
+      testAndAssert({});
+    });
+
+    it('should be `true` when there are tokens, but they are all already expired', () => {
+      testAndAssert({
+        expired: [
+          tokenFixtures.expired[Expired.yesterday],
+          tokenFixtures.expired[Expired.day_before_yesterday],
+        ],
+        unexpired: [],
+      });
+    });
+
+    it('should be `true` when the only token is not-yet-expired, but will be tomorrow', () => {
+      testAndAssert({
+        unexpiredButInvalid: [tokenFixtures.unexpiredButInvalid[UnexpiredButInvalid.tomorrow]],
+      });
+    });
+
+    it('should be `true` when a mixture of unexpired and expired tokens exist, but the unexpired will be expired tomorrow or later today', () => {
+      testAndAssert({
+        expired: [
+          tokenFixtures.expired[Expired.yesterday],
+          tokenFixtures.expired[Expired.day_before_yesterday],
+        ],
+        unexpiredButInvalid: [
+          tokenFixtures.unexpiredButInvalid[UnexpiredButInvalid.later_today],
+          tokenFixtures.unexpiredButInvalid[UnexpiredButInvalid.tomorrow],
+        ],
+      });
+    });
+
+    it('should be `true` when a mixture of unexpired and expired tokens exist, but the unexpired will be expired later today', () => {
+      testAndAssert({
+        expired: [
+          tokenFixtures.expired[Expired.yesterday],
+          tokenFixtures.expired[Expired.day_before_yesterday],
+        ],
+        unexpiredButInvalid: [tokenFixtures.unexpiredButInvalid[UnexpiredButInvalid.later_today]],
+      });
+    });
+
+    it('should be `true` when a mixture of unexpired and expired tokens exist, but the unexpired only will be expired tomorrow', () => {
+      testAndAssert({
+        expired: [
+          tokenFixtures.expired[Expired.yesterday],
+          tokenFixtures.expired[Expired.day_before_yesterday],
+        ],
+        unexpiredButInvalid: [tokenFixtures.unexpiredButInvalid[UnexpiredButInvalid.tomorrow]],
+      });
+    });
+
+    it('should be `true` when the only tokens that exist will expire later today', () => {
+      testAndAssert({
+        unexpiredButInvalid: [tokenFixtures.unexpiredButInvalid[UnexpiredButInvalid.later_today]],
+      });
+    });
+
+    it('should be `true` when the only tokens that exist will expire tomorrow', () => {
+      testAndAssert({
+        unexpiredButInvalid: [tokenFixtures.unexpiredButInvalid[UnexpiredButInvalid.tomorrow]],
+      });
+    });
+
+    it('should be `false` when the only token that exists expires farther in the future than tomorrow', () => {
+      testAndAssert({
+        unexpired: [tokenFixtures.unexpired[Unexpired.day_after_tomorrow]],
+      });
+    });
+
+    it('should be `false` when all tokens that exists expire farther in the future than tomorrow', () => {
+      testAndAssert({
+        unexpired: [
+          tokenFixtures.unexpired[Unexpired.day_after_tomorrow],
+          tokenFixtures.unexpired[Unexpired.next_week],
+          tokenFixtures.unexpired[Unexpired.two_weeks_from_now],
+        ],
+      });
+    });
+
+    it('should be `false` when some tokens that exist expire farther in the future than tomorrow even when others are expired', () => {
+      testAndAssert({
+        expired: [
+          tokenFixtures.expired[Expired.yesterday],
+          tokenFixtures.expired[Expired.day_before_yesterday],
+        ],
+        unexpired: [
+          tokenFixtures.unexpired[Unexpired.day_after_tomorrow],
+          tokenFixtures.unexpired[Unexpired.next_week],
+          tokenFixtures.unexpired[Unexpired.two_weeks_from_now],
+        ],
+      });
+    });
+
+    it('should be `false` when some tokens that exist expire farther in the future than tomorrow even when others are expired and some are unexpired but invalid', () => {
+      testAndAssert({
+        expired: [
+          tokenFixtures.expired[Expired.yesterday],
+          tokenFixtures.expired[Expired.day_before_yesterday],
+        ],
+        unexpired: [
+          tokenFixtures.unexpired[Unexpired.day_after_tomorrow],
+          tokenFixtures.unexpired[Unexpired.next_week],
+          tokenFixtures.unexpired[Unexpired.two_weeks_from_now],
+        ],
+        unexpiredButInvalid: [
+          tokenFixtures.unexpiredButInvalid[UnexpiredButInvalid.tomorrow],
+          tokenFixtures.unexpiredButInvalid[UnexpiredButInvalid.later_today],
+        ],
+      });
+    });
+
+    it('should be `false` when some tokens that exist expire farther in the future than tomorrow even when others are expired and one unexpired will expire later today', () => {
+      testAndAssert({
+        expired: [
+          tokenFixtures.expired[Expired.yesterday],
+          tokenFixtures.expired[Expired.day_before_yesterday],
+        ],
+        unexpired: [
+          tokenFixtures.unexpired[Unexpired.day_after_tomorrow],
+          tokenFixtures.unexpired[Unexpired.next_week],
+          tokenFixtures.unexpired[Unexpired.two_weeks_from_now],
+        ],
+        unexpiredButInvalid: [tokenFixtures.unexpiredButInvalid[UnexpiredButInvalid.later_today]],
+      });
+    });
+
+    it('should be `false` when some tokens that exist expire farther in the future than tomorrow even when others are expired and one unexpired will expire tomorrow', () => {
+      testAndAssert({
+        expired: [
+          tokenFixtures.expired[Expired.yesterday],
+          tokenFixtures.expired[Expired.day_before_yesterday],
+        ],
+        unexpired: [
+          tokenFixtures.unexpired[Unexpired.day_after_tomorrow],
+          tokenFixtures.unexpired[Unexpired.next_week],
+          tokenFixtures.unexpired[Unexpired.two_weeks_from_now],
+        ],
+        unexpiredButInvalid: [tokenFixtures.unexpiredButInvalid[UnexpiredButInvalid.tomorrow]],
+      });
+    });
+  });
+});

--- a/packages/lit-task-auto-top-up/tests/expiredTokens/expiredTokens.ts
+++ b/packages/lit-task-auto-top-up/tests/expiredTokens/expiredTokens.ts
@@ -44,7 +44,7 @@ function testAndAssert({
   return true;
 }
 describe('Expired Tokens', () => {
-  describe('noUnexpiredTokensTomorrow', () => {
+  describe('noUsableTokensTomorrow', () => {
     it('should be `true` when there are no tokens at all', () => {
       testAndAssert({});
     });

--- a/packages/lit-task-auto-top-up/tests/expiredTokens/tokenFixtures.ts
+++ b/packages/lit-task-auto-top-up/tests/expiredTokens/tokenFixtures.ts
@@ -1,0 +1,162 @@
+import date from 'date-and-time';
+
+import { CapacityToken } from '../../src/types/types';
+
+// Note that we consider later today and tomorrow expired even though `isExpired` will be `false` for them
+export enum Expired {
+  day_before_yesterday = 'day_before_yesterday',
+  yesterday = 'yesterday',
+}
+
+export enum Unexpired {
+  day_after_tomorrow = 'day_after_tomorrow',
+  next_week = 'next_week',
+  two_weeks_from_now = 'two_weeks_from_now',
+}
+
+export enum UnexpiredButInvalid {
+  later_today = 'later_today',
+  tomorrow = 'tomorrow',
+}
+
+interface TokenFixtures {
+  expired: Record<Expired, CapacityToken>;
+  unexpired: Record<Unexpired, CapacityToken>;
+  unexpiredButInvalid: Record<UnexpiredButInvalid, CapacityToken>;
+}
+function getMidnightToday(now: Date) {
+  const midnightDate = new Date(now);
+  midnightDate.setHours(0, 0, 0, 0);
+  return midnightDate;
+}
+
+export const NOW = new Date(1712157737877);
+export const MIDNIGHT_TODAY = getMidnightToday(NOW);
+export const DAY_BEFORE_YESTERDAY = date.addDays(MIDNIGHT_TODAY, -2);
+export const YESTERDAY = date.addDays(MIDNIGHT_TODAY, -1);
+export const LATER_TODAY = date.addHours(NOW, 2);
+export const TOMORROW = date.addDays(MIDNIGHT_TODAY, 1);
+export const DAY_AFTER_TOMORROW = date.addDays(MIDNIGHT_TODAY, 2);
+export const NEXT_WEEK = date.addDays(MIDNIGHT_TODAY, 7);
+export const TWO_WEEKS_FROM_NOW = date.addDays(MIDNIGHT_TODAY, 14);
+
+export const tokenFixtures: TokenFixtures = {
+  expired: {
+    [Expired.day_before_yesterday]: {
+      URI: {
+        description: 'This is a test token that expired the day before yesterday.',
+        image_data: 'This would be an SVG',
+        name: 'Capacity Token',
+      },
+      capacity: {
+        expiresAt: {
+          formatted: DAY_BEFORE_YESTERDAY.toISOString(),
+          timestamp: DAY_BEFORE_YESTERDAY.getTime(),
+        },
+        requestsPerMillisecond: 50,
+      },
+      isExpired: true,
+      tokenId: 123,
+    },
+    [Expired.yesterday]: {
+      URI: {
+        description: 'This is a test token that expired yesterday.',
+        image_data: 'This would be an SVG',
+        name: 'Capacity Token',
+      },
+      capacity: {
+        expiresAt: {
+          formatted: YESTERDAY.toISOString(),
+          timestamp: YESTERDAY.getTime(),
+        },
+        requestsPerMillisecond: 50,
+      },
+      isExpired: true,
+      tokenId: 3214,
+    },
+  },
+  unexpired: {
+    [Unexpired.day_after_tomorrow]: {
+      URI: {
+        description: 'This is a test token that will expire the day after tomorrow',
+        image_data: 'This would be an SVG',
+        name: 'Capacity Token',
+      },
+      capacity: {
+        expiresAt: {
+          formatted: DAY_AFTER_TOMORROW.toISOString(),
+          timestamp: DAY_AFTER_TOMORROW.getTime(),
+        },
+        requestsPerMillisecond: 50,
+      },
+      isExpired: false,
+      tokenId: 264,
+    },
+    [Unexpired.next_week]: {
+      URI: {
+        description: 'This is a test token that will expire next week',
+        image_data: 'This would be an SVG',
+        name: 'Capacity Token',
+      },
+      capacity: {
+        expiresAt: {
+          formatted: NEXT_WEEK.toISOString(),
+          timestamp: NEXT_WEEK.getTime(),
+        },
+        requestsPerMillisecond: 50,
+      },
+      isExpired: false,
+      tokenId: 26267,
+    },
+    [Unexpired.two_weeks_from_now]: {
+      URI: {
+        description: 'This is a test token that will expire two weeks from now',
+        image_data: 'This would be an SVG',
+        name: 'Capacity Token',
+      },
+      capacity: {
+        expiresAt: {
+          formatted: TWO_WEEKS_FROM_NOW.toISOString(),
+          timestamp: TWO_WEEKS_FROM_NOW.getTime(),
+        },
+        requestsPerMillisecond: 50,
+      },
+      isExpired: false,
+      tokenId: 3597935,
+    },
+  },
+  unexpiredButInvalid: {
+    [UnexpiredButInvalid.later_today]: {
+      URI: {
+        description: 'This is a test token that will expire later today',
+        image_data: 'This would be an SVG',
+        name: 'Capacity Token',
+      },
+      capacity: {
+        expiresAt: {
+          formatted: LATER_TODAY.toISOString(),
+          timestamp: LATER_TODAY.getTime(),
+        },
+        requestsPerMillisecond: 50,
+      },
+      isExpired: false,
+      tokenId: 54762,
+    },
+    [UnexpiredButInvalid.tomorrow]: {
+      URI: {
+        description: 'This is a test token that will expire tomorrow.',
+        image_data: 'This would be an SVG',
+        name: 'Capacity Token',
+      },
+      capacity: {
+        expiresAt: {
+          formatted: TOMORROW.toISOString(),
+          timestamp: TOMORROW.getTime(),
+        },
+        requestsPerMillisecond: 50,
+      },
+      isExpired: false,
+      tokenId: 34643,
+    },
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,12 +117,21 @@ importers:
       awaity:
         specifier: ^1.0.0
         version: 1.0.0
+      bs58:
+        specifier: ^5.0.0
+        version: 5.0.0
       consola:
         specifier: ^3.2.3
         version: 3.2.3
+      date-and-time:
+        specifier: 2.4.1
+        version: 2.4.1
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      multiformats:
+        specifier: 9.7.1
+        version: 9.7.1
       verror:
         specifier: ^1.10.1
         version: 1.10.1
@@ -133,6 +142,9 @@ importers:
         specifier: ^3.22.4
         version: 3.22.4
     devDependencies:
+      '@types/date-and-time':
+        specifier: 0.13.0
+        version: 0.13.0
       chai:
         specifier: ^5.1.0
         version: 5.1.0
@@ -2592,6 +2604,10 @@ packages:
     resolution: {integrity: sha512-Wj71sXE4Q4AkGdG9Tvq1u/fquNz9EdG4LIJMwVVII7ashjD/8cf8fyIfJAjRr6YcsXnSE8cOGQPq1gqeR8z+3w==}
     dev: true
 
+  /@types/date-and-time@0.13.0:
+    resolution: {integrity: sha512-kHEncapIgrqaY8r2tyb19EvdKyhNjwheLl5cYTorsWJtURoI+oGm5ehW8CLAaq4dvu8x9z56FcXqAT4Mm5Nvzw==}
+    dev: true
+
   /@types/debug@4.1.12:
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
     dependencies:
@@ -3786,6 +3802,10 @@ packages:
       es-errors: 1.3.0
       is-data-view: 1.0.1
     dev: true
+
+  /date-and-time@2.4.1:
+    resolution: {integrity: sha512-fG+ClATev+wHryqxOoGcTTegr5RhYE+tz/XHUkTQ/zvpWqQ90oOxjOhuMQ02bw87Oy9N3qBENCHHHSKdWJjgTg==}
+    dev: false
 
   /date.js@0.3.3:
     resolution: {integrity: sha512-HgigOS3h3k6HnW011nAb43c5xx5rBXk8P2v/WIT9Zv4koIaVXiH2BURguI78VVp+5Qc076T7OR378JViCnZtBw==}
@@ -6091,6 +6111,10 @@ packages:
   /multiformats@12.1.3:
     resolution: {integrity: sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+    dev: false
+
+  /multiformats@9.7.1:
+    resolution: {integrity: sha512-TaVmGEBt0fhxiNJMGphBfB+oGvUxFs8KgGvgl8d3C+GWtrFcvXdJ2196eg+dYhmSFClmgFfSfJEklo+SZzdNuw==}
     dev: false
 
   /mute-stream@1.0.0:


### PR DESCRIPTION
Adds new logic to avoid minting a new NFT to recipients every day, which would lead to a single recipient having many NFTs in cases where the NFT we mint for them expires many days in the future.

Logic is:
- Only mint a new NFT if the target recipient will have no un-expired NFTs tomorrow.  Otherwise, skip 'em and log the NFTs that won't be expired tomorrow (both their IDs and their `expiredAt` formatted string :)).

Props to @mmmmveggies for awesome `.filter()` prop-based predicate for discriminated unions.. That is fly stuff; I was struggling with how to do that for `PromiseSettledResults` last week but gave up :P