### PR TITLE
feat(lit-task-auto-top-up):  Update worker to support 1-task-per-network on a single mongodb backend task tracking instance

### DIFF
--- a/bin/validateJSONRecipients.ts
+++ b/bin/validateJSONRecipients.ts
@@ -2,6 +2,11 @@ import { recipientDetailSchema } from 'lit-task-auto-top-up';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { z } from 'zod';
 
-import recipientList from '../worker/recipient_list.json' assert { type: 'json' };
+// TODO: Delete this file and reference once PR #5 is merged and the existing worker has been updated to use the new habanero-specific path
+import deprecatedHabaneroRecipientList from '../worker/recipient_list.json' assert { type: 'json' };
+import habanberoRecipientList from '../worker/recipient_list_habanero.json' assert { type: 'json' };
+import manzanoRecipientList from '../worker/recipient_list_manzano.json' assert { type: 'json' };
 
-z.array(recipientDetailSchema).parse(recipientList);
+z.array(recipientDetailSchema).parse(deprecatedHabaneroRecipientList);
+z.array(recipientDetailSchema).parse(habanberoRecipientList);
+z.array(recipientDetailSchema).parse(manzanoRecipientList);

--- a/packages/lit-task-auto-top-up/package.json
+++ b/packages/lit-task-auto-top-up/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@hokify/agenda": "^6.3.0",
-    "@lit-protocol/contracts-sdk": "^4.1.1",
+    "@lit-protocol/contracts-sdk": "^6.1.0",
     "awaity": "^1.0.0",
     "bs58": "^5.0.0",
     "consola": "^3.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,8 +112,8 @@ importers:
         specifier: ^6.3.0
         version: 6.3.0
       '@lit-protocol/contracts-sdk':
-        specifier: ^4.1.1
-        version: 4.1.1
+        specifier: ^6.1.0
+        version: 6.1.0
       awaity:
         specifier: ^1.0.0
         version: 1.0.0
@@ -1808,40 +1808,29 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
-  /@lit-protocol/accs-schemas@0.0.6:
-    resolution: {integrity: sha512-/NIZkAN+kgAarWefBX1a4DiNerUtv8JOdQmqUo45cnlDp89X9HkiK+8gm9z2p9gojtvxMqqId7wW8J8NHXVRDg==}
+  /@lit-protocol/accs-schemas@0.0.7:
+    resolution: {integrity: sha512-n8fJ6NMh2T3KgSKe0CRB0Uam6ZwxUTQV0oQXY0vEmSL+Q2a1PsM2FX42szOM+O7LgY+Bko7AiCjjDHbqQoJydg==}
     dependencies:
       ajv: 8.12.0
     dev: false
 
-  /@lit-protocol/auth-helpers@4.1.1(ethers@5.7.2):
-    resolution: {integrity: sha512-N1wzaDwsGhfeOlirb3KgubsvqRZFQFGkVgFRQl4wyNshueyaY2VwVTDj869pf2DVKapzC17C8OZfE2r10j3WpA==}
-    dependencies:
-      siwe: 2.1.4(ethers@5.7.2)
-      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2)
-    transitivePeerDependencies:
-      - ethers
-    dev: false
-
-  /@lit-protocol/constants@4.1.1:
-    resolution: {integrity: sha512-FmJEAweMGvOnQrWh4B3Bxdt2EdWKjwIXZp3McSlCbAdVvqTumj3qRrCqmPummJ1ajelxePKuwHZ17xv0yTnJMg==}
+  /@lit-protocol/constants@6.1.0:
+    resolution: {integrity: sha512-PuLZ+1K5NizuQ7N+S/4Z81+yyWICTQE7T2BFcWYPjvTX0HbUp0hiVfeFwH9J0c2eZs6sok9LRpMXE4RD5LRzRw==}
     dependencies:
       '@ethersproject/abstract-provider': 5.7.0
-      '@lit-protocol/accs-schemas': 0.0.6
-      '@lit-protocol/auth-helpers': 4.1.1(ethers@5.7.2)
-      '@lit-protocol/types': 4.1.1
+      '@lit-protocol/accs-schemas': 0.0.7
+      '@lit-protocol/types': 6.1.0
       ethers: 5.7.2
       jszip: 3.10.1
       siwe: 2.1.4(ethers@5.7.2)
-      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2)
-      tslib: 2.6.2
+      tslib: 1.14.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
     dev: false
 
-  /@lit-protocol/contracts-sdk@4.1.1:
-    resolution: {integrity: sha512-Rxid+7hO6UzPlPthPl3gxHckqnZx5QQ3Qgu0aEhTkX4MP4PC5d1by4Kh8cpXdU7uWPCJT+TtkpyEwtuDSep79A==}
+  /@lit-protocol/contracts-sdk@6.1.0:
+    resolution: {integrity: sha512-jKuhtJM0rP0bFPyWtiLzLA1rmbG6sy0CT+RxTAudLbcB5QE8sYqU4jv320+JY3BOTyGy8X9l3OArNZEP0BR3mg==}
     dependencies:
       '@cosmjs/amino': 0.30.1
       '@cosmjs/crypto': 0.30.1
@@ -1850,12 +1839,11 @@ packages:
       '@ethersproject/abstract-provider': 5.7.0
       '@ethersproject/contracts': 5.7.0
       '@ethersproject/providers': 5.7.2
-      '@lit-protocol/accs-schemas': 0.0.6
-      '@lit-protocol/auth-helpers': 4.1.1(ethers@5.7.2)
-      '@lit-protocol/constants': 4.1.1
-      '@lit-protocol/logger': 4.1.1
-      '@lit-protocol/misc': 4.1.1
-      '@lit-protocol/types': 4.1.1
+      '@lit-protocol/accs-schemas': 0.0.7
+      '@lit-protocol/constants': 6.1.0
+      '@lit-protocol/logger': 6.1.0
+      '@lit-protocol/misc': 6.1.0
+      '@lit-protocol/types': 6.1.0
       ajv: 8.12.0
       bitcoinjs-lib: 6.1.5
       ethers: 5.7.2
@@ -1864,8 +1852,7 @@ packages:
       process: 0.11.10
       punycode: 2.3.1
       siwe: 2.1.4(ethers@5.7.2)
-      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2)
-      tslib: 2.6.2
+      tslib: 1.14.1
       uint8arrays: 4.0.10
       util: 0.12.5
     transitivePeerDependencies:
@@ -1873,44 +1860,40 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@lit-protocol/logger@4.1.1:
-    resolution: {integrity: sha512-TATuhj8uxQvZYD5XDFeni6NyVQSTqbJbs3gZaqmt99/yYap2RtTpeNoy5305pXmbjgaAVItaV0G3+Un34lFd8A==}
+  /@lit-protocol/logger@6.1.0:
+    resolution: {integrity: sha512-jjeISmjkjWsXsyBixXlbU1QH1T19qUnpCl2mCb8gsxHTcUoHWTN9yJtdKzbuhgjg2Cru5qPgy6hbkiAWeD4woQ==}
     dependencies:
       '@ethersproject/abstract-provider': 5.7.0
-      '@lit-protocol/accs-schemas': 0.0.6
-      '@lit-protocol/auth-helpers': 4.1.1(ethers@5.7.2)
-      '@lit-protocol/constants': 4.1.1
-      '@lit-protocol/types': 4.1.1
+      '@lit-protocol/accs-schemas': 0.0.7
+      '@lit-protocol/constants': 6.1.0
+      '@lit-protocol/types': 6.1.0
       ethers: 5.7.2
       jszip: 3.10.1
       punycode: 2.3.1
       siwe: 2.1.4(ethers@5.7.2)
-      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2)
-      tslib: 2.6.2
+      tslib: 1.14.1
       uint8arrays: 4.0.10
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
     dev: false
 
-  /@lit-protocol/misc@4.1.1:
-    resolution: {integrity: sha512-uVNWtnb+gLGCUY1uqbfJDkMObduzkaQ1dIHgZdMKTiElp0xRG4KinGhAhMT6wOsXYO2eIVw6DFdAJfMcUVhwtA==}
+  /@lit-protocol/misc@6.1.0:
+    resolution: {integrity: sha512-ii6O4J42XFa2beDbHFZu+Voq46Onbg7NzhmwG+GN2dS3t2adMlVIfMSYOUcC6xUQHR4v10IF4UhbjBQ4kBeslg==}
     dependencies:
       '@ethersproject/abstract-provider': 5.7.0
       '@ethersproject/contracts': 5.7.0
       '@ethersproject/providers': 5.7.2
-      '@lit-protocol/accs-schemas': 0.0.6
-      '@lit-protocol/auth-helpers': 4.1.1(ethers@5.7.2)
-      '@lit-protocol/constants': 4.1.1
-      '@lit-protocol/logger': 4.1.1
-      '@lit-protocol/types': 4.1.1
+      '@lit-protocol/accs-schemas': 0.0.7
+      '@lit-protocol/constants': 6.1.0
+      '@lit-protocol/logger': 6.1.0
+      '@lit-protocol/types': 6.1.0
       ajv: 8.12.0
       ethers: 5.7.2
       jszip: 3.10.1
       punycode: 2.3.1
       siwe: 2.1.4(ethers@5.7.2)
-      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2)
-      tslib: 2.6.2
+      tslib: 1.14.1
       uint8arrays: 4.0.10
       util: 0.12.5
     transitivePeerDependencies:
@@ -1918,17 +1901,15 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@lit-protocol/types@4.1.1:
-    resolution: {integrity: sha512-d0oq6JU4Ls0n7aJ/7duH3y9gXaWO3++1RaJeKvwRkfpRLKCsfLNCl+yfvcRD+LHSADeMYTN1b99dLY9ao+5u7Q==}
+  /@lit-protocol/types@6.1.0:
+    resolution: {integrity: sha512-FLujzG3vmeZYlfobr/FerxEH2rFVs3xo+yZOm6WaEQhzF8mhptuMgwwSq1jV9OnGlimDMofXXgP6DwKna4GnzQ==}
     dependencies:
       '@ethersproject/abstract-provider': 5.7.0
-      '@lit-protocol/accs-schemas': 0.0.6
-      '@lit-protocol/auth-helpers': 4.1.1(ethers@5.7.2)
+      '@lit-protocol/accs-schemas': 0.0.7
       ethers: 5.7.2
       jszip: 3.10.1
       siwe: 2.1.4(ethers@5.7.2)
-      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2)
-      tslib: 2.6.2
+      tslib: 1.14.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -3363,10 +3344,6 @@ packages:
   /caniuse-lite@1.0.30001599:
     resolution: {integrity: sha512-LRAQHZ4yT1+f9LemSMeqdMpMxZcc4RMWdj4tiFe3G8tNkWK+E58g+/tzotb5cU6TbcVJLr4fySiAW7XmxQvZQA==}
     dev: true
-
-  /canonicalize@2.0.0:
-    resolution: {integrity: sha512-ulDEYPv7asdKvqahuAY35c1selLdzDwHqugK92hfkzvlDCwXRRelDkR+Er33md/PtnpqHemgkuDPanZ4fiYZ8w==}
-    dev: false
 
   /chai@5.1.0:
     resolution: {integrity: sha512-kDZ7MZyM6Q1DhR9jy7dalKohXQ2yrlXkk59CR52aRKxJrobmlBNqnFQxX9xOX8w+4mz8SYlKJa/7D7ddltFXCw==}
@@ -6103,11 +6080,6 @@ packages:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: true
 
-  /multiformats@11.0.2:
-    resolution: {integrity: sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dev: false
-
   /multiformats@12.1.3:
     resolution: {integrity: sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
@@ -7169,17 +7141,6 @@ packages:
       is-arrayish: 0.3.2
     dev: true
 
-  /siwe-recap@0.0.2-alpha.0(ethers@5.7.2):
-    resolution: {integrity: sha512-xqFUnvrACWW/Q4s5HQ02avg8IyH2RcgkUzfvN4scYaaHErotLVtTGDZkSS0sn/oNK4MXRt83lTqredsvXgt8iA==}
-    peerDependencies:
-      ethers: ^5.5.1
-    dependencies:
-      canonicalize: 2.0.0
-      ethers: 5.7.2
-      multiformats: 11.0.2
-      siwe: 2.1.4(ethers@5.7.2)
-    dev: false
-
   /siwe@2.1.4(ethers@5.7.2):
     resolution: {integrity: sha512-Dke1Qqa3mgiLm3vjqw/+SQ7dl8WV/Pfk3AlQBF94cBFydTYhztngqYrikzE3X5UTsJ6565dfVbQptszsuYZNYg==}
     peerDependencies:
@@ -7494,6 +7455,7 @@ packages:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     requiresBuild: true
     dev: false
+    optional: true
 
   /tsutils@3.21.0(typescript@5.4.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}

--- a/worker/recipient_list.json
+++ b/worker/recipient_list.json
@@ -1,8 +1,8 @@
 [
   {
     "recipientAddress": "0x9f32f6555a117ac137775973C6856bC52c249C80",
-    "daysUntilExpires": 5,
-    "requestsPerSecond": 5
+    "daysUntilExpires": 20,
+    "requestsPerSecond": 20
   },
   {
     "recipientAddress": "0xB34f1F28F25485b074c623D3711F4b5ea91d9CFb",
@@ -25,4 +25,3 @@
     "requestsPerSecond": 10000
   }
 ]
-    

--- a/worker/recipient_list_habanero.json
+++ b/worker/recipient_list_habanero.json
@@ -1,0 +1,23 @@
+[
+  {
+    "recipientAddress": "0x9f32f6555a117ac137775973C6856bC52c249C80",
+    "daysUntilExpires": 5,
+    "requestsPerSecond": 5
+  },
+  {
+    "recipientAddress": "0xB34f1F28F25485b074c623D3711F4b5ea91d9CFb",
+    "daysUntilExpires": 15,
+    "requestsPerSecond": 15
+  },
+  {
+    "recipientAddress": "0x1F62583538CDB2CB3656Ed43A46693F92DDa6302",
+    "daysUntilExpires": 30,
+    "requestsPerSecond": 10000
+  },
+  {
+    "recipientAddress": "0x4447D4d650cE9E63E21D2AA799e8016dEBf1e272",
+    "daysUntilExpires": 30,
+    "requestsPerSecond": 10000
+  }
+]
+    

--- a/worker/recipient_list_habanero.json
+++ b/worker/recipient_list_habanero.json
@@ -18,5 +18,10 @@
     "recipientAddress": "0x4447D4d650cE9E63E21D2AA799e8016dEBf1e272",
     "daysUntilExpires": 30,
     "requestsPerSecond": 10000
+  },
+  {
+    "recipientAddress": "0x4b271D43c38D91f3791E97f31942A22e124DF441",
+    "daysUntilExpires": 30,
+    "requestsPerSecond": 10000
   }
 ]

--- a/worker/recipient_list_habanero.json
+++ b/worker/recipient_list_habanero.json
@@ -1,8 +1,8 @@
 [
   {
     "recipientAddress": "0x9f32f6555a117ac137775973C6856bC52c249C80",
-    "daysUntilExpires": 5,
-    "requestsPerSecond": 5
+    "daysUntilExpires": 20,
+    "requestsPerSecond": 20
   },
   {
     "recipientAddress": "0xB34f1F28F25485b074c623D3711F4b5ea91d9CFb",
@@ -20,4 +20,3 @@
     "requestsPerSecond": 10000
   }
 ]
-    

--- a/worker/recipient_list_manzano.json
+++ b/worker/recipient_list_manzano.json
@@ -1,7 +1,7 @@
 [
   {
     "recipientAddress": "0x9f32f6555a117ac137775973C6856bC52c249C80",
-    "daysUntilExpires": 5,
-    "requestsPerSecond": 5
+    "daysUntilExpires": 20,
+    "requestsPerSecond": 20
   }
 ]

--- a/worker/recipient_list_manzano.json
+++ b/worker/recipient_list_manzano.json
@@ -1,0 +1,7 @@
+[
+  {
+    "recipientAddress": "0x9f32f6555a117ac137775973C6856bC52c249C80",
+    "daysUntilExpires": 5,
+    "requestsPerSecond": 5
+  }
+]

--- a/worker/worker.ts
+++ b/worker/worker.ts
@@ -10,7 +10,7 @@ const taskClient = createTaskClient({ config: taskClientConfig });
 
 const autoTopUpTaskConfig = getAutoTopUpTaskConfig();
 const autoTopUpTaskHandler = new AutoTopUpTaskHandler({ config: autoTopUpTaskConfig });
-const AUTO_TOP_UP_TASK_NAME = `daily ${autoTopUpTaskName}`;
+const AUTO_TOP_UP_TASK_NAME = `daily ${autoTopUpTaskName} - ${autoTopUpTaskConfig.envConfig.LIT_NETWORK}`;
 
 async function gogo() {
   taskClient.start().then(async () => {


### PR DESCRIPTION
With this PR, we can run multiple worker instances (1 per network), but persist their jobs to a single backend Mongo instance without issue.

- Updated the lit auto-top-up worker definition to register a network-specific daily task job name for Agenda.
- Added a new `recipient_list_manzano.json` file in the `worker` directory, which our new manzano instance can be configured via env var to load.
- Duplicated the existing `recipient_list.json` file in the `worker` directory, which was habanero specific.  The new file includes `habanero` in the same for consistency.  Once this is merged and the existing worker is updated to reference the new filename with `habanero` in it, we can delete the existing generically named `recipient_list.json` file.
- Modified entries for `0x9f32f6555a117ac137775973C6856bC52c249C80` in all 3 files -- this address is a 'stub' address that I use as a canary for the job/worker; it is a wallet that I created.  It was set to mint every 5 days. I changed it to mint every 20 instead.