### PR TITLE
LIT-3860 - Ensure we are validating recipient lists for all supported networks in CI and commit checks

### DIFF
--- a/bin/validateJSONRecipients.ts
+++ b/bin/validateJSONRecipients.ts
@@ -1,9 +1,33 @@
-import { recipientDetailSchema } from 'lit-task-auto-top-up';
+import { recipientDetailSchema, SUPPORTED_LIT_NETWORKS } from 'lit-task-auto-top-up';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { z } from 'zod';
 
+import cayenneRecipientList from '../worker/recipient_list_cayenne.json' assert { type: 'json' };
+import datilTestRecipientList from '../worker/recipient_list_datil-test.json' assert { type: 'json' };
+import datilRecipientList from '../worker/recipient_list_datil.json' assert { type: 'json' };
 import habaneroRecipientList from '../worker/recipient_list_habanero.json' assert { type: 'json' };
 import manzanoRecipientList from '../worker/recipient_list_manzano.json' assert { type: 'json' };
 
-z.array(recipientDetailSchema).parse(habaneroRecipientList);
-z.array(recipientDetailSchema).parse(manzanoRecipientList);
+const networks = SUPPORTED_LIT_NETWORKS.options;
+
+// Ensures we are validating the shape of a recipient list for every network that we support
+const recipientListsMap: Record<
+  z.infer<typeof SUPPORTED_LIT_NETWORKS>,
+  z.infer<typeof recipientDetailSchema>[]
+> = {
+  cayenne: cayenneRecipientList,
+  datil: datilRecipientList,
+  'datil-test': datilTestRecipientList,
+  habanero: habaneroRecipientList,
+  manzano: manzanoRecipientList,
+};
+
+networks.forEach((network: z.infer<typeof SUPPORTED_LIT_NETWORKS>) => {
+  const list = recipientListsMap[network];
+
+  if (!list) {
+    throw new Error(`Missing recipient list at 'worker/recipient_list_${network}'`);
+  }
+
+  z.array(recipientDetailSchema).parse(list);
+});

--- a/packages/lit-task-auto-top-up/src/index.ts
+++ b/packages/lit-task-auto-top-up/src/index.ts
@@ -1,4 +1,4 @@
 export { taskName } from './constants';
 export { TaskHandler } from './Classes/TaskHandler';
 export { getConfig } from './singletons/getConfig';
-export { recipientDetailSchema } from './types/schemas';
+export { recipientDetailSchema, SUPPORTED_LIT_NETWORKS } from './types/schemas';

--- a/packages/lit-task-auto-top-up/src/types/schemas.ts
+++ b/packages/lit-task-auto-top-up/src/types/schemas.ts
@@ -21,9 +21,15 @@ export const requiredConfigSchema = {
   NFT_MINTER_KEY: z.string().min(32),
 };
 
-const LIT_NETWORKS = z.enum(['cayenne', 'custom', 'manzano', 'habanero', 'datil', 'datil-test']);
+export const SUPPORTED_LIT_NETWORKS = z.enum([
+  'cayenne', // Playground for testing refactors/critical changes
+  'manzano',
+  'habanero',
+  'datil',
+  'datil-test',
+]);
 export const optionalConfigSchema = {
-  LIT_NETWORK: LIT_NETWORKS.default('cayenne'),
+  LIT_NETWORK: SUPPORTED_LIT_NETWORKS.default('cayenne'),
   RECIPIENT_LIST_URL: z.string().default(DEFAULT_RECIPIENT_LIST_URL),
 };
 export const envConfigSchema = z.intersection(

--- a/worker/recipient_list_cayenne.json
+++ b/worker/recipient_list_cayenne.json
@@ -1,0 +1,7 @@
+[
+  {
+    "recipientAddress": "0x9f32f6555a117ac137775973C6856bC52c249C80",
+    "daysUntilExpires": 5,
+    "requestsPerSecond": 5
+  }
+]


### PR DESCRIPTION
Adds code that will ensure we are validating the structure of every json recipient file (for every supported network)
- This is also now typesafe, so `tsc` will error if a supported network is not implemented in `bin/validateJSONRecipients.ts`