### PR TITLE
Multiply seconds timestamp from chain by 1000 to convert to milliseconds

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "pnpm -r run test",
     "dev": "pnpm build && pnpm dotenvx run -- node ./dist/worker/worker_test_run_now.js",
     "start": "pnpm build && node ./dist/worker/worker.js",
+    "runNow": "node ./dist/worker/worker_test_run_now.js",
     "prepare": "husky",
     "ci_validate": "node ./dist/bin/validateJSONRecipients.js",
     "validate": "pnpm build && node ./dist/bin/validateJSONRecipients.js"

--- a/packages/lit-task-auto-top-up/src/Classes/TaskHandler.ts
+++ b/packages/lit-task-auto-top-up/src/Classes/TaskHandler.ts
@@ -82,6 +82,10 @@ export class TaskHandler {
         return true;
       }
       const tokenExpiresDate = new TZDate(timestamp, 'UTC');
+      this.logger.log('timestamp from contract', timestamp);
+      this.logger.log('tokenExpiresDate', tokenExpiresDate);
+      this.logger.log('tomorrow', tomorrow);
+      this.logger.log('today', today);
       return isSameDay(tokenExpiresDate, tomorrow) || isSameDay(tokenExpiresDate, today);
     });
     return {

--- a/packages/lit-task-auto-top-up/src/Classes/TaskHandler.ts
+++ b/packages/lit-task-auto-top-up/src/Classes/TaskHandler.ts
@@ -82,10 +82,6 @@ export class TaskHandler {
         return true;
       }
       const tokenExpiresDate = new TZDate(timestamp * 1000, 'UTC');
-      this.logger.log('timestamp from contract', timestamp);
-      this.logger.log('tokenExpiresDate', tokenExpiresDate);
-      this.logger.log('tomorrow', tomorrow);
-      this.logger.log('today', today);
       return isSameDay(tokenExpiresDate, tomorrow) || isSameDay(tokenExpiresDate, today);
     });
     return {

--- a/packages/lit-task-auto-top-up/src/Classes/TaskHandler.ts
+++ b/packages/lit-task-auto-top-up/src/Classes/TaskHandler.ts
@@ -81,7 +81,7 @@ export class TaskHandler {
       if (isExpired) {
         return true;
       }
-      const tokenExpiresDate = new TZDate(timestamp, 'UTC');
+      const tokenExpiresDate = new TZDate(timestamp * 1000, 'UTC');
       this.logger.log('timestamp from contract', timestamp);
       this.logger.log('tokenExpiresDate', tokenExpiresDate);
       this.logger.log('tomorrow', tomorrow);

--- a/packages/lit-task-auto-top-up/tests/expiredTokens/tokenFixtures.ts
+++ b/packages/lit-task-auto-top-up/tests/expiredTokens/tokenFixtures.ts
@@ -57,7 +57,7 @@ export const tokenFixtures: TokenFixtures = {
       capacity: {
         expiresAt: {
           formatted: DAY_BEFORE_YESTERDAY.toISOString(),
-          timestamp: DAY_BEFORE_YESTERDAY.getTime(),
+          timestamp: DAY_BEFORE_YESTERDAY.getTime() / 1000, // the real data from the contract is in seconds
         },
         requestsPerMillisecond: 50,
       },
@@ -73,7 +73,7 @@ export const tokenFixtures: TokenFixtures = {
       capacity: {
         expiresAt: {
           formatted: YESTERDAY.toISOString(),
-          timestamp: YESTERDAY.getTime(),
+          timestamp: YESTERDAY.getTime() / 1000, // the real data from the contract is in seconds
         },
         requestsPerMillisecond: 50,
       },
@@ -91,7 +91,7 @@ export const tokenFixtures: TokenFixtures = {
       capacity: {
         expiresAt: {
           formatted: DAY_AFTER_TOMORROW.toISOString(),
-          timestamp: DAY_AFTER_TOMORROW.getTime(),
+          timestamp: DAY_AFTER_TOMORROW.getTime() / 1000, // the real data from the contract is in seconds
         },
         requestsPerMillisecond: 50,
       },
@@ -107,7 +107,7 @@ export const tokenFixtures: TokenFixtures = {
       capacity: {
         expiresAt: {
           formatted: NEXT_WEEK.toISOString(),
-          timestamp: NEXT_WEEK.getTime(),
+          timestamp: NEXT_WEEK.getTime() / 1000, // the real data from the contract is in seconds,
         },
         requestsPerMillisecond: 50,
       },
@@ -123,7 +123,7 @@ export const tokenFixtures: TokenFixtures = {
       capacity: {
         expiresAt: {
           formatted: TWO_WEEKS_FROM_NOW.toISOString(),
-          timestamp: TWO_WEEKS_FROM_NOW.getTime(),
+          timestamp: TWO_WEEKS_FROM_NOW.getTime() / 1000, // the real data from the contract is in seconds,
         },
         requestsPerMillisecond: 50,
       },
@@ -141,7 +141,7 @@ export const tokenFixtures: TokenFixtures = {
       capacity: {
         expiresAt: {
           formatted: LATER_TODAY.toISOString(),
-          timestamp: LATER_TODAY.getTime(),
+          timestamp: LATER_TODAY.getTime() / 1000, // the real data from the contract is in seconds,
         },
         requestsPerMillisecond: 50,
       },
@@ -157,7 +157,7 @@ export const tokenFixtures: TokenFixtures = {
       capacity: {
         expiresAt: {
           formatted: TOMORROW.toISOString(),
-          timestamp: TOMORROW.getTime(),
+          timestamp: TOMORROW.getTime() / 1000, // the real data from the contract is in seconds,
         },
         requestsPerMillisecond: 50,
       },


### PR DESCRIPTION
This PR multiplies the timestamp from chain by 1000 to convert it to milliseconds, since that's what the JS date constructor needs.

I discovered this by adding additional logs (since removed, but was in this commit https://github.com/LIT-Protocol/lit-scheduled-tasks/pull/18/commits/830bc2c9bece4dc65b8f509478eade6c02979c78) and you can see the result from a run below.  The tokenExpiresDate is wrong because it expects timestamps in milliseconds, and we passed one in seconds, resulting in a date of `1970-01-21T00:53:16.800Z`.

```
timestamp from contract 1731196800                                                                                                                                                                                                 
tokenExpiresDate { TZDate 1970-01-21T00:53:16.800Z timeZone: 'UTC', internal: 1970-01-21T00:53:16.800Z }                                                                                                                           
tomorrow { TZDate 2024-11-03T00:44:49.827Z timeZone: 'UTC', internal: 2024-11-03T00:44:49.827Z }                                                                                                                                   
today { TZDate 2024-11-02T00:44:49.827Z timeZone: 'UTC', internal: 2024-11-02T00:44:49.827Z }
```